### PR TITLE
Fix PHP 8 compatibility issues

### DIFF
--- a/app/settings/mib_definition_create.php
+++ b/app/settings/mib_definition_create.php
@@ -58,7 +58,7 @@ $html[] = " <th colspan='4'><hr></th>";
 $html[] = " </tr>";
 
 // content
-foreach ($mib->notification_objects_full as $k=>$o) {
+foreach (is_array($mib->notification_objects_full) ? $mib->notification_objects_full : array() as $k=>$o) {
 
 $Trap_read->process_oid ("$mib->oid::$o");
 

--- a/functions/classes/class.Notify.php
+++ b/functions/classes/class.Notify.php
@@ -563,7 +563,7 @@ class mail {
         	$this->Php_mailer->AltBody = $mail_content_plain;
         	//send
         	$this->Php_mailer->send();
-        } catch (phpmailerException $e) {
+        } catch (PHPMailer\PHPMailer\Exception $e) {
         	$this->write_error ("Mailer Error: ".$e->errorMessage());
         } catch (Exception $e) {
         	$this->write_error ("Mailer Error: ".$e->errorMessage());
@@ -767,7 +767,6 @@ class pushover {
                 "priority" => $this->p_priority,
                 "message" => implode("\n", $message_details->content)
             ),
-            CURLOPT_SAFE_UPLOAD => true,
             )
         );
         // send

--- a/functions/classes/class.User.php
+++ b/functions/classes/class.User.php
@@ -569,7 +569,7 @@ class User extends Common_functions {
     private function detect_crypt_type () {
         if(CRYPT_SHA512 == 1)        { return '$6$rounds=3000$'; }
         elseif(CRYPT_SHA256 == 1)    { return '$5$rounds=3000$'; }
-        elseif(CRYPT_BLOWFISH == 1)    { return '$2y$'.str_pad(rand(4,31),2,0, STR_PAD_LEFT).'$'; }
+        elseif(CRYPT_BLOWFISH == 1)    { return '$2y$'.str_pad(rand(4,31),2,'0', STR_PAD_LEFT).'$'; }
         elseif(CRYPT_MD5 == 1)        { return '$5$rounds=3000$'; }
         else                        { $this->Result->show("danger", _("No crypt types supported"), true); }
     }

--- a/functions/classes/class.traphandler.php
+++ b/functions/classes/class.traphandler.php
@@ -222,7 +222,7 @@ class Trap {
             }
         }
         else {
-            $this->message_details->content = "NONE";
+            $this->message_details->content = array("NONE");
         }
     }
 
@@ -237,11 +237,13 @@ class Trap {
         $this->message_details->severity = "unknown";
 
         // loop through message, search for Severity in each content, default null
+        if (is_array($this->message_details->content)) {
         foreach ($this->message_details->content as $c) {
             if (strpos($c, "Severity")!==false || strpos($c, "severity")!==false) {
                 $tmp = explode(" => ", $c);
                 $this->message_details->severity = $tmp[1];
             }
+        }
         }
 
         // search database for exceptions and definitions
@@ -277,6 +279,7 @@ class Trap {
         // changed flag
         $changed = false;
         // loop through message, search for Severity in each content, default null
+        if (is_array($this->message_details->content)) {
         foreach ($search_values as $sv) {
             foreach ($this->message_details->content as $c) {
                 if ( strpos($c, $sv)!==false ) {
@@ -285,6 +288,7 @@ class Trap {
                     $changed = true;
                 }
             }
+        }
         }
         // detect and format special messages
         $this->detect_special_messages ();
@@ -353,7 +357,7 @@ class Trap {
                 // explode
                 $c = explode(" => ", $c);
                 // check - first name, then status
-                if (strpos($c[0], "vtpVlanName")!==false)     { $this->message_details->msg .= " :: ".$c[1]." (vlan ".array_pop(explode(".", $c[0])).")"; }
+                if (strpos($c[0], "vtpVlanName")!==false)     { $tmp_arr = explode(".", $c[0]); $this->message_details->msg .= " :: ".$c[1]." (vlan ".array_pop($tmp_arr).")"; }
            }
         }
     }
@@ -619,6 +623,7 @@ class Trap {
                                  "CISCO-SYSLOG-MIB::clogHistFacility",
                                  "CISCO-SYSLOG-MIB::clogHistTimestamp");
         // check and remove
+        if (is_array($this->message_details->content)) {
         foreach ($unneeded_values as $uv) {
             foreach ($this->message_details->content as $k=>$c) {
                 //content explode
@@ -628,6 +633,7 @@ class Trap {
                     unset($this->message_details->content[$k]);
                 }
             }
+        }
         }
     }
 }

--- a/functions/version.php
+++ b/functions/version.php
@@ -40,4 +40,4 @@ $version['patch']  = "1";
  * @var mixed
  * @access public
  */
-$version['php'] = "7.0";
+$version['php'] = "8.0";

--- a/traphandler.php
+++ b/traphandler.php
@@ -51,7 +51,7 @@ try {
 
 
     # --- write trap to database
-    $Trap->write_t1rap ();
+    $Trap->write_trap ();
 
 
     # --- send notification


### PR DESCRIPTION
- Remove CURLOPT_SAFE_UPLOAD (removed in PHP 7.4/8.0)
- Fix phpmailerException -> PHPMailer\PHPMailer\Exception class name
- Fix write_t1rap() typo -> write_trap()
- Fix content "NONE" string to array to prevent foreach on non-iterable
- Guard foreach with is_array() checks for content and detect_msg()
- Fix foreach on false from detect_mib_objects() in mib_definition_create.php
- Fix str_pad() integer 0 argument -> string '0' (PHP 8.1 TypeError)
- Fix array_pop(explode()) non-variable by-reference argument
- Update minimum required PHP version from 7.0 to 8.0

https://claude.ai/code/session_016AZsfdLXAGcttR2S6kGqgJ